### PR TITLE
Fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -54,6 +54,6 @@ jobs:
       run: mvn clean package -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -28,13 +28,6 @@ jobs:
     - name: Build with Maven
       run: mvn clean package -B
 
-    - name: Run tests
-      run: mvn test -B
-
-    - name: Generate coverage report
-      if: matrix.java == '17'
-      run: mvn jacoco:report
-
     - name: Upload build artifacts
       if: matrix.java == '17'
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Fix issues in GitHub Actions workflows to ensure CI/CD pipeline runs correctly.

## Changes
- Remove JaCoCo coverage report step from maven-build workflow (plugin not configured in pom.xml)
- Update CodeQL Action from v3 to v4 (v3 will be deprecated in December 2026)
- Remove redundant test step (already included in mvn package)

## Test plan
- [x] Maven build workflow runs successfully
- [x] CodeQL analysis completes without deprecation warnings
- [x] Build artifacts are uploaded correctly