### PR TITLE
Remove Maven Central downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Proxmox VE API Client for Java (Made in Italy)
 
 [![License](https://img.shields.io/github/license/Corsinvest/cv4pve-api-java.svg?style=flat-square)](LICENSE)
 [![Java](https://img.shields.io/badge/Java-17%2B-blue?style=flat-square&logo=java)](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
-[![Maven Central](https://img.shields.io/maven-metadata/v.svg?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fit%2Fcorsinvest%2Fproxmoxve%2Fapi%2Fcv4pve-api-java%2Fmaven-metadata.xml&label=maven-central&style=flat-square)](https://central.sonatype.com/artifact/it.corsinvest.proxmoxve/cv4pve-api-java)
-[![Maven Central Downloads](https://img.shields.io/maven-central/dm/it.corsinvest.proxmoxve/cv4pve-api-java?style=flat-square&label=downloads)](https://central.sonatype.com/artifact/it.corsinvest.proxmoxve/cv4pve-api-java)
+[![Maven Central](https://img.shields.io/maven-metadata/v.svg?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fit%2Fcorsinvest%2Fproxmoxve%2Fcv4pve-api-java%2Fmaven-metadata.xml&label=maven-central&style=flat-square)](https://central.sonatype.com/artifact/it.corsinvest.proxmoxve/cv4pve-api-java)
 
 </div>
 
@@ -60,16 +59,6 @@ if (client.login("root@pam", "your-password")) {
     System.out.println("VM: " + vm.get("name").asText());
 }
 ```
-
----
-
-## Package Suite
-
-### [cv4pve-api-java](./docs/api.md)
-
-[![Maven Central](https://img.shields.io/maven-central/v/it.corsinvest.proxmoxve/cv4pve-api-java.svg?style=flat-square)](https://search.maven.org/artifact/it.corsinvest.proxmoxve/cv4pve-api-java)
-
-Core Java client library for Proxmox VE API. Foundation package with complete API coverage.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove Maven Central downloads badge that returns 404 error
- Fix Maven Central version badge URL (remove incorrect `/api/` path segment)
- Remove redundant "Package Suite" section

## Details
The downloads badge from shields.io (`maven-central/dm/`) returns a 404 error for this artifact, likely because shields.io doesn't support download statistics for artifacts published via Sonatype Central Portal.

Additionally fixed the Maven Central version badge URL which incorrectly contained `/api/` in the path.

## Test plan
- [x] Verify version badge displays correctly
- [x] Confirm downloads badge removed
- [x] Check README renders properly on GitHub