### PR TITLE
Fix busy-waiting in waitForTaskToFinish - bump to 9.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!-- === PROJECT INFO === -->
     <groupId>it.corsinvest.proxmoxve</groupId>
     <artifactId>cv4pve-api-java</artifactId>
-    <version>9.1.1</version>
+    <version>9.1.2</version>
     <packaging>jar</packaging>
 
     <name>cv4pve-api-java</name>

--- a/src/main/java/it/corsinvest/proxmoxve/api/PveClientBase.java
+++ b/src/main/java/it/corsinvest/proxmoxve/api/PveClientBase.java
@@ -579,11 +579,13 @@ public class PveClientBase {
         }
 
         var timeStart = System.currentTimeMillis();
-        var waitTime = System.currentTimeMillis();
         while (isRunning && (System.currentTimeMillis() - timeStart) < timeOut) {
-            if ((System.currentTimeMillis() - waitTime) >= wait) {
-                waitTime = System.currentTimeMillis();
-                isRunning = taskIsRunning(task);
+            isRunning = taskIsRunning(task);
+            try {
+                Thread.sleep(wait);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             }
         }
 


### PR DESCRIPTION
## Summary

- Replace CPU-intensive busy-wait loop with `Thread.sleep(wait)` in `waitForTaskToFinish`
- Properly handle `InterruptedException` by restoring thread interrupt flag
- Remove redundant `waitTime` variable
- Bump version to `9.1.2`

## Test plan

- [ ] Verify `waitForTaskToFinish` waits the correct amount of time between checks
- [ ] Verify thread interrupt is handled correctly
- [ ] Confirm CPU usage is reduced during task polling