### PR TITLE
Mask sensitive parameters in debug logs

### DIFF
--- a/src/main/java/it/corsinvest/proxmoxve/api/PveClientBase.java
+++ b/src/main/java/it/corsinvest/proxmoxve/api/PveClientBase.java
@@ -476,8 +476,19 @@ public class PveClientBase {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Method: {0}, Url: {1}", new Object[] { httpMethod, url });
                 if (methodType != MethodType.GET && !params.isEmpty()) {
+                    var sensitiveParams = new String[] { "password", "token", "ticket", "otp", "apitoken" };
                     var paramsStr = new StringBuilder("Parameters:");
-                    params.forEach((key, value) -> paramsStr.append("\n  ").append(key).append(" : ").append(value));
+                    params.forEach((key, value) -> {
+                        var paramName = key.toLowerCase();
+                        var isSensitive = false;
+                        for (var p : sensitiveParams) {
+                            if (paramName.contains(p)) {
+                                isSensitive = true;
+                                break;
+                            }
+                        }
+                        paramsStr.append("\n  ").append(key).append(" : ").append(isSensitive ? "****" : value);
+                    });
                     logger.fine(paramsStr.toString());
                 }
             }


### PR DESCRIPTION
## Summary
Mask sensitive parameter values in FINE-level request logging.

Parameters whose name contains `password`, `token`, `ticket`, `otp` or `apitoken` are now logged as `****` instead of their actual value. This aligns the Java client with the existing behavior of the .NET implementation (`PveClientBase.cs`).

## Changes
- `PveClientBase.java`: mask sensitive params in the debug log of `executeAction`.

## Notes
- Only affects logging output; request behavior is unchanged.
- Compiles cleanly (JDK 23, Jackson 2.18.6).