### PR TITLE
chore: update build plugins, drop unused JUnit, bump to 9.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!-- === PROJECT INFO === -->
     <groupId>it.corsinvest.proxmoxve</groupId>
     <artifactId>cv4pve-api-java</artifactId>
-    <version>9.2.0</version>
+    <version>9.2.1</version>
     <packaging>jar</packaging>
 
     <name>cv4pve-api-java</name>
@@ -60,7 +60,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <jackson.version>2.18.9</jackson.version>
-        <junit.version>5.10.0</junit.version>
     </properties>
 
     <!-- === DEPENDENCIES === -->
@@ -81,21 +80,6 @@
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-
-        <!-- JUnit Jupiter -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <!-- === DISTRIBUTION MANAGEMENT (Central Portal) === -->
@@ -113,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -123,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -138,7 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.3</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -153,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.8</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -172,7 +156,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
@@ -184,7 +168,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.3</version>
                 <configuration>
                     <mainClass>it.corsinvest.proxmoxve.api.Test</mainClass>
                     <classpathScope>test</classpathScope>
@@ -213,7 +197,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -229,7 +213,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Why

Release `9.2.0` was published to Maven Central with jackson `2.18.6`. The security fix merged in #28 (jackson `2.18.9`, closing all 8 open Dependabot alerts) therefore exists only on `master` — no downloadable artifact contains it. Central is immutable, so `9.2.0` cannot be republished. This bumps to `9.2.1` so a patched release can go out.

## Changes

**Version:** `9.2.0` → `9.2.1`

**Build plugins** — all were well behind current:

| Plugin | From | To |
|---|---|---|
| maven-compiler-plugin | 3.11.0 | 3.15.0 |
| maven-source-plugin | 3.3.0 | 3.4.0 |
| maven-javadoc-plugin | 3.6.3 | 3.12.0 |
| maven-gpg-plugin | 3.2.1 | 3.2.8 |
| exec-maven-plugin | 3.1.0 | 3.6.3 |
| central-publishing-maven-plugin | 0.7.0 | 0.11.0 |

`maven-gpg-plugin` and `central-publishing-maven-plugin` are declared **twice** — once in `<build>` and again in the `release` profile. Both occurrences are updated; updating only the first would have left the actual release path on the old versions.

**Removed** `junit-jupiter-api` and `junit-jupiter-engine` plus the `junit.version` property. The only file under `src/test` is `Test.java`, a manual `main()` that connects to a live Proxmox host and prints output. It imports no JUnit API, declares no `@Test`, and runs via `exec-maven-plugin` rather than surefire — these dependencies were never used.

**Jackson stays on `2.18.9`.** It already closes every open alert (highest `first_patched` across the 8 is `2.18.9`), and the jump to `2.22.x` was deliberately declined in #27.

## Verification

Built locally with the NetBeans-bundled Maven 3.9.15:

```
mvn -P dev clean package -B   →  BUILD SUCCESS
```

All three release artifacts are produced — the same ones `publish-maven.yml` attaches to the GitHub release:

- `cv4pve-api-java-9.2.1.jar` (628 KB)
- `cv4pve-api-java-9.2.1-sources.jar` (146 KB)
- `cv4pve-api-java-9.2.1-javadoc.jar` (2587 KB)

The javadoc jar was the main risk in this change (3.6.3 → 3.12.0 brings stricter doclint); it builds fine. The 100 javadoc warnings are all `no comment` / `no description for @param` on the generated `PveClient.java` — pre-existing, not introduced here.

**Not covered by this local build:** it ran on JDK 23, whereas CI uses 17 and 21 — that is what this PR's checks will confirm. The `-P dev` profile also skips GPG signing, so `mvn deploy -P release` with real signing remains unexercised until the tag (gpg is only a patch bump, 3.2.1 → 3.2.8).
